### PR TITLE
Fix nonsandbox dupe botnames

### DIFF
--- a/lib/rtanque/bot_sandbox.rb
+++ b/lib/rtanque/bot_sandbox.rb
@@ -24,20 +24,12 @@ module RTanque
           bots = get_diff_in_object_space(RTanque::Bot::Brain) do
             eval @code
           end
-          botName = bots[0].to_s
-          newBotName = "RTanque::BotSandbox::BestBotEver" << Kernel.rand(100000).to_s
+          botName = bots[0].to_s.split('::').last
+          newBotName = "BestBotEver" << Kernel.rand(100000).to_s
           puts botName
           puts newBotName
-          eval("#{newBotName} = #{botName}")
-          # botName.demodulize
-          # if self.class.Camper
-          class << self
-            undef_const :Camper
-          end
-          # end
-          # RTanque::BotSandbox.class.(:undef, :Camper)
-          # Object.send(:remove_const, :RTanque::BotSandbox::Camper)
-          bots = [self.string_to_class(newBotName)]
+          self.redef_class(botName, newBotName)
+          bots = [self.class.const_get(newBotName)]
         end
 
         if bots.length == 1
@@ -50,11 +42,17 @@ module RTanque
 
     protected
 
-    def string_to_class(str)
-      str.split('::').inject(Object) do |mod, class_name|
-        mod.const_get(class_name)
-      end
+    def redef_class(const, new_const)
+      tmp = self.class.const_get(const)
+      self.class.send(:remove_const, const)
+      self.class.const_set(new_const, tmp)
     end
+
+    # def string_to_class(str)
+    #   str.split('::').inject(Object) do |mod, class_name|
+    #     mod.const_get(class_name)
+    #   end
+    # end
 
     def add_helpers(namespace)
       namespace.const_set :BOT_RADIUS, Bot::RADIUS

--- a/lib/rtanque/bot_sandbox.rb
+++ b/lib/rtanque/bot_sandbox.rb
@@ -26,8 +26,6 @@ module RTanque
           end
           botName = bots[0].to_s.split('::').last
           newBotName = "BestBotEver" << Kernel.rand(100000).to_s
-          puts botName
-          puts newBotName
           self.redef_class(botName, newBotName)
           bots = [self.class.const_get(newBotName)]
         end
@@ -47,12 +45,6 @@ module RTanque
       self.class.send(:remove_const, const)
       self.class.const_set(new_const, tmp)
     end
-
-    # def string_to_class(str)
-    #   str.split('::').inject(Object) do |mod, class_name|
-    #     mod.const_get(class_name)
-    #   end
-    # end
 
     def add_helpers(namespace)
       namespace.const_set :BOT_RADIUS, Bot::RADIUS

--- a/lib/rtanque/bot_sandbox.rb
+++ b/lib/rtanque/bot_sandbox.rb
@@ -24,6 +24,20 @@ module RTanque
           bots = get_diff_in_object_space(RTanque::Bot::Brain) do
             eval @code
           end
+          botName = bots[0].to_s
+          newBotName = "RTanque::BotSandbox::BestBotEver" << Kernel.rand(100000).to_s
+          puts botName
+          puts newBotName
+          eval("#{newBotName} = #{botName}")
+          # botName.demodulize
+          # if self.class.Camper
+          class << self
+            undef_const :Camper
+          end
+          # end
+          # RTanque::BotSandbox.class.(:undef, :Camper)
+          # Object.send(:remove_const, :RTanque::BotSandbox::Camper)
+          bots = [self.string_to_class(newBotName)]
         end
 
         if bots.length == 1
@@ -35,6 +49,12 @@ module RTanque
     end
 
     protected
+
+    def string_to_class(str)
+      str.split('::').inject(Object) do |mod, class_name|
+        mod.const_get(class_name)
+      end
+    end
 
     def add_helpers(namespace)
       namespace.const_set :BOT_RADIUS, Bot::RADIUS


### PR DESCRIPTION
Renames the incoming bot classes to random classes.
This hasn't been thoroughly tested but seems to work fine.

One issue is the bot name is sometimes incorrect.
